### PR TITLE
Fix warning: The value None of attribute 'temperature' is not a valid dual temperature.

### DIFF
--- a/hass_apps/schedy/actor/dualthermostat.py
+++ b/hass_apps/schedy/actor/dualthermostat.py
@@ -201,11 +201,11 @@ class DualThermostatActor(ActorBase):
     def check_config_plausibility(self, state: dict) -> None:
         """Is called during initialization to warn the user about some
         possible common configuration mistakes."""
-
+    
         if not state:
             self.log("Thermostat couldn't be found.", level="WARNING")
             return
-
+    
         required_attrs = ["target_temp_high", "target_temp_low"]
         if self.cfg["supports_hvac_modes"]:
             required_attrs.append("state")
@@ -216,20 +216,20 @@ class DualThermostatActor(ActorBase):
                     "Please check your config!".format(attr, list(state.keys())),
                     level="WARNING",
                 )
-
-        temp_attrs = ["temperature", "current_temperature"]
+    
+        temp_attrs = ["target_temp_high", "target_temp_low", "current_temperature"]
         for attr in temp_attrs:
             value = state.get(attr)
             try:
                 value = float(value)  # type: ignore
             except (TypeError, ValueError):
                 self.log(
-                    "The value {!r} of attribute {!r} is not a valid dual temperature.".format(
+                    "The value {!r} of attribute {!r} is not a valid temperature.".format(
                         value, attr
                     ),
                     level="WARNING",
                 )
-
+    
         allowed_hvac_modes = state.get("hvac_modes")
         if not self.cfg["supports_hvac_modes"]:
             if allowed_hvac_modes:
@@ -241,7 +241,7 @@ class DualThermostatActor(ActorBase):
                     level="WARNING",
                 )
             return
-
+    
         if not allowed_hvac_modes:
             self.log(
                 "Attributes for thermostat contain no 'hvac_modes', Consider "

--- a/hass_apps/schedy/actor/dualthermostat.py
+++ b/hass_apps/schedy/actor/dualthermostat.py
@@ -201,11 +201,11 @@ class DualThermostatActor(ActorBase):
     def check_config_plausibility(self, state: dict) -> None:
         """Is called during initialization to warn the user about some
         possible common configuration mistakes."""
-    
+
         if not state:
             self.log("Thermostat couldn't be found.", level="WARNING")
             return
-    
+
         required_attrs = ["target_temp_high", "target_temp_low"]
         if self.cfg["supports_hvac_modes"]:
             required_attrs.append("state")
@@ -216,7 +216,7 @@ class DualThermostatActor(ActorBase):
                     "Please check your config!".format(attr, list(state.keys())),
                     level="WARNING",
                 )
-    
+
         temp_attrs = ["target_temp_high", "target_temp_low", "current_temperature"]
         for attr in temp_attrs:
             value = state.get(attr)
@@ -229,7 +229,7 @@ class DualThermostatActor(ActorBase):
                     ),
                     level="WARNING",
                 )
-    
+
         allowed_hvac_modes = state.get("hvac_modes")
         if not self.cfg["supports_hvac_modes"]:
             if allowed_hvac_modes:
@@ -241,7 +241,7 @@ class DualThermostatActor(ActorBase):
                     level="WARNING",
                 )
             return
-    
+
         if not allowed_hvac_modes:
             self.log(
                 "Attributes for thermostat contain no 'hvac_modes', Consider "


### PR DESCRIPTION
Fixes this warning:

`2024-05-26 10:57:36.227694 WARNING schedy_heating: !!! [R:living] [A:climate.thermostat] The value None of attribute 'temperature' is not a valid dual temperature.`

Occurs due to `temperature` attribute being null for dual thermostat. Now checks the correct temp attributes `target_temp_high` and `target_temp_low`.